### PR TITLE
Reposition labels and entry field when not displayed as lock screen

### DIFF
--- a/LTHPasscodeViewController/LTHPasscodeViewController.m
+++ b/LTHPasscodeViewController/LTHPasscodeViewController.m
@@ -417,7 +417,7 @@ static const CGFloat kFailedAttemptLabelHeight = 22.0f;
 	
 	
 	CGFloat verticalGap = is4InchDevice() ? kVerticalGap4Inch : self.displayedAsLockScreen ? kVerticalGap35Inch : kVerticalGap35Inch + 15.0f;
-	CGFloat topSpacing = is4InchDevice() ? kTopSpacing4Inch :self.displayedAsLockScreen ? kTopSpacing35Inch : kTopSpacing35Inch + 30.0f;
+	CGFloat topSpacing = is4InchDevice() ? kTopSpacing4Inch : self.displayedAsLockScreen ? kTopSpacing35Inch : kTopSpacing35Inch + 30.0f;
 	
 	NSLayoutConstraint *enterPasscodeConstraintCenterX =
     [NSLayoutConstraint constraintWithItem: _enterPasscodeLabel


### PR DESCRIPTION
Fixes wheel-ios issue #1312
https://github.com/biowink/wheel-iOS/issues/1312
